### PR TITLE
Switch default branch from master to main

### DIFF
--- a/.github/workflows/updated-notification.yaml
+++ b/.github/workflows/updated-notification.yaml
@@ -3,7 +3,7 @@ name: Notify definitions were updated
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   trigger-webhook:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ There are two ways of contribution:
 
    1. By running `pre-commit install` after cloning the repo. Then definitions will be
       converted automatically before each commit
-   2. By creating a PR to the `master` branch. CI workflow will run the automation and
+   2. By creating a PR to the `main` branch. CI workflow will run the automation and
       push updated/generated files if needed.
 
 ## Python sources


### PR DESCRIPTION
Also updated black, the old version crashed with ImportError: cannot import name '_unicodefun' from 'click' (/home/runner/.cache/pre-commit/repohhqp09a7/py_env-python3/lib/python3.9/site-packages/click/__init__.py)